### PR TITLE
Replace --no-confirmation default action.

### DIFF
--- a/src/bundles/UserBundle/Command/ProcessUserAgeDemographicsCommand.php
+++ b/src/bundles/UserBundle/Command/ProcessUserAgeDemographicsCommand.php
@@ -47,7 +47,7 @@ EOT
 
         $context = $input->getArgument('context');
 
-        if ($input->getOption('no-confirmation') || $dialog->askConfirmation($output, 'Confirm user age demographics processing?', false)) {
+        if ($input->getOption('no-confirmation') || $dialog->askConfirmation($output, 'Confirm user age demographics processing?', true)) {
             $output->writeln(array(
                     '',
                     '<info>Start processing user age demographics!</info>',


### PR DESCRIPTION
Flip --no-confirmation for command bruery:user:process-user-age-demographics to allow automated execution.